### PR TITLE
fixed load_collection: temporal_extent and spatial_extent defaults, polygon/geoJSON support

### DIFF
--- a/src/openeo_odc/map_processes_odc.py
+++ b/src/openeo_odc/map_processes_odc.py
@@ -23,13 +23,13 @@ def map_load_collection(id, process):
 
     params = {
         'product': process['arguments']['id'],
-        'x': (process['arguments']['spatial_extent']['west'],
-              process['arguments']['spatial_extent']['east']),
-        'y': (process['arguments']['spatial_extent']['south'],
-              process['arguments']['spatial_extent']['north']),
-        'time': process['arguments']['temporal_extent'],
         'dask_chunks': {'time': 'auto', 'x': 1000, 'y': 1000},
         }
+    if 'spatial_extent' in process['arguments'] and process['arguments']['spatial_extent'] is not None:
+        params['x'] = (process['arguments']['spatial_extent']['west'],process['arguments']['spatial_extent']['east'])
+        params['y'] = (process['arguments']['spatial_extent']['south'],process['arguments']['spatial_extent']['north'])
+    if 'temporal_extent' in process['arguments']['temporal_extent'] and process['arguments']['temporal_extent'] is not None:
+        params['time'] = process['arguments']['temporal_extent']
     if 'crs' in process['arguments']['spatial_extent']:
         params['crs'] = process['arguments']['spatial_extent']['crs']
     if 'bands' in process['arguments']:

--- a/src/openeo_odc/map_processes_odc.py
+++ b/src/openeo_odc/map_processes_odc.py
@@ -4,6 +4,8 @@
 
 
 def map_load_collection(id, process):
+    from datetime import datetime
+    import numpy as np
     """ Map to load_collection process for ODC datacubes.
 
     Creates a string like the following:
@@ -25,11 +27,36 @@ def map_load_collection(id, process):
         'product': process['arguments']['id'],
         'dask_chunks': {'time': 'auto', 'x': 1000, 'y': 1000},
         }
-    if 'spatial_extent' in process['arguments'] and process['arguments']['spatial_extent'] is not None:
-        params['x'] = (process['arguments']['spatial_extent']['west'],process['arguments']['spatial_extent']['east'])
-        params['y'] = (process['arguments']['spatial_extent']['south'],process['arguments']['spatial_extent']['north'])
-    if 'temporal_extent' in process['arguments']['temporal_extent'] and process['arguments']['temporal_extent'] is not None:
-        params['time'] = process['arguments']['temporal_extent']
+    if 'spatial_extent' in process['arguments']:
+        if process['arguments']['spatial_extent'] is not None:
+            if 'south' in process['arguments']['spatial_extent'] and \
+               'north' in process['arguments']['spatial_extent'] and \
+               'east'  in process['arguments']['spatial_extent'] and \
+               'west'  in process['arguments']['spatial_extent']:
+                params['x'] = (process['arguments']['spatial_extent']['west'],process['arguments']['spatial_extent']['east'])
+                params['y'] = (process['arguments']['spatial_extent']['south'],process['arguments']['spatial_extent']['north'])
+            elif 'coordinates' in process['arguments']['spatial_extent']:
+                # Pass coordinates to odc and process them there
+                # TODO: data has to be masked after loading with a polygon
+                polygon = process['arguments']['spatial_extent']['coordinates']
+                if polygon is not None:
+                    lowLat      = np.min([[el[1] for el in polygon[0]]])
+                    highLat     = np.max([[el[1] for el in polygon[0]]])
+                    lowLon      = np.min([[el[0] for el in polygon[0]]])
+                    highLon     = np.max([[el[0] for el in polygon[0]]])
+                    params['x'] = (lowLon,highLon)
+                    params['y'] = (lowLat,highLat)
+    if 'temporal_extent' in process['arguments']:
+        def exclusive_date(date):
+            return str(np.datetime64(date) - np.timedelta64(1, 'D')).split(' ')[0] # Substracts one day
+        if process['arguments']['temporal_extent'] is not None:
+            timeStart = '1970-01-01'
+            timeEnd   = str(datetime.now()).split(' ')[0] # Today is the default date for timeEnd, to include all the dates if not specified
+            if process['arguments']['temporal_extent'][0] is not None:
+                timeStart = process['arguments']['temporal_extent'][0]
+            if process['arguments']['temporal_extent'][1] is not None:
+                timeEnd = process['arguments']['temporal_extent'][1]
+            params['time'] = [timeStart,exclusive_date(timeEnd)] 
     if 'crs' in process['arguments']['spatial_extent']:
         params['crs'] = process['arguments']['spatial_extent']['crs']
     if 'bands' in process['arguments']:

--- a/src/openeo_odc/map_to_odc.py
+++ b/src/openeo_odc/map_to_odc.py
@@ -56,13 +56,23 @@ def resolve_from_parameter(node):
 
 def create_job_header(odc_env: str, dask_url: str):
     """Create job imports."""
+    if odc_env is None:
+        return f"""from dask.distributed import Client
+    import datacube
+    import openeo_processes as oeop
 
-    return f"""from dask.distributed import Client
-import datacube
-import openeo_processes as oeop
+    # Initialize ODC instance
+    cube = datacube.Datacube()
+    # Connect to Dask Scheduler
+    client = Client('{dask_url}')
+    """
+    else:
+        return f"""from dask.distributed import Client
+    import datacube
+    import openeo_processes as oeop
 
-# Initialize ODC instance
-cube = datacube.Datacube(app='app_1', env='{odc_env}')
-# Connect to Dask Scheduler
-client = Client('{dask_url}')
-"""
+    # Initialize ODC instance
+    cube = datacube.Datacube(app='app_1', env='{odc_env}')
+    # Connect to Dask Scheduler
+    client = Client('{dask_url}')
+    """

--- a/tests/backend_processes.json
+++ b/tests/backend_processes.json
@@ -1723,6 +1723,153 @@
       "summary": "Minimum value"
     },
     {
+      "id": "median",
+      "summary": "Statistical median",
+      "description": "The statistical median of an array of numbers is the value separating the higher half from the lower half of the data.\n\nAn array without non-`null` elements resolves always with `null`.\n\n**Remarks:**\n\n* For a symmetric arrays, the result is equal to the ``mean()``.\n* The median can also be calculated by computing the ``quantiles()`` with a probability of *0.5*.",
+      "categories": [
+        "math",
+        "reducer"
+      ],
+      "parameters": [
+        {
+          "name": "data",
+          "description": "An array of numbers.",
+          "schema": {
+            "type": "array",
+            "items": {
+              "type": [
+                "number",
+                "null"
+              ]
+            }
+          }
+        },
+        {
+          "name": "ignore_nodata",
+          "description": "Indicates whether no-data values are ignored or not. Ignores them by default. Setting this flag to `false` considers no-data values so that `null` is returned if any value is such a value.",
+          "schema": {
+            "type": "boolean"
+          },
+          "default": true,
+          "optional": true
+        }
+      ],
+      "returns": {
+        "description": "The computed statistical median.",
+        "schema": {
+          "type": [
+            "number",
+            "null"
+          ]
+        }
+      },
+      "examples": [
+        {
+          "arguments": {
+            "data": [
+              1,
+              3,
+              3,
+              6,
+              7,
+              8,
+              9
+            ]
+          },
+          "returns": 6
+        },
+        {
+          "arguments": {
+            "data": [
+              1,
+              2,
+              3,
+              4,
+              5,
+              6,
+              8,
+              9
+            ]
+          },
+          "returns": 4.5
+        },
+        {
+          "arguments": {
+            "data": [
+              -1,
+              -0.5,
+              null,
+              1
+            ]
+          },
+          "returns": -0.5
+        },
+        {
+          "arguments": {
+            "data": [
+              -1,
+              0,
+              null,
+              1
+            ],
+            "ignore_nodata": false
+          },
+          "returns": null
+        },
+        {
+          "description": "The input array is empty: return `null`.",
+          "arguments": {
+            "data": []
+          },
+          "returns": null
+        },
+        {
+          "description": "The input array has only `null` elements: return `null`.",
+          "arguments": {
+            "data": [
+              null,
+              null
+            ]
+          },
+          "returns": null
+        }
+      ],
+      "links": [
+        {
+          "rel": "about",
+          "href": "http://mathworld.wolfram.com/StatisticalMedian.html",
+          "title": "Statistical Median explained by Wolfram MathWorld"
+        }
+      ],
+      "process_graph": {
+        "quantiles": {
+          "process_id": "quantiles",
+          "arguments": {
+            "data": {
+              "from_parameter": "data"
+            },
+            "probabilities": [
+              0.5
+            ],
+            "ignore_nodata": {
+              "from_parameter": "ignore_nodata"
+            }
+          }
+        },
+        "array_element": {
+          "process_id": "array_element",
+          "arguments": {
+            "data": {
+              "from_node": "quantiles"
+            },
+            "return_nodata": true,
+            "index": 0
+          },
+          "result": true
+        }
+      }
+    },
+    {
       "categories": [
         "cubes",
         "reducer"


### PR DESCRIPTION
1. The web editor creates by default the load_collection without temporal_extent, this was not handled. Same for spatial_extent.
2. Allow to call cube = datacube.Datacube(), without app and env, setting odc_env=None in create_job_header