### PR TITLE
Extend processes

### DIFF
--- a/src/openeo_odc/map_processes_odc.py
+++ b/src/openeo_odc/map_processes_odc.py
@@ -1,11 +1,11 @@
 """
 
 """
+from datetime import datetime
+import numpy as np
 
 
 def map_load_collection(id, process):
-    from datetime import datetime
-    import numpy as np
     """ Map to load_collection process for ODC datacubes.
 
     Creates a string like the following:

--- a/src/openeo_odc/map_processes_odc.py
+++ b/src/openeo_odc/map_processes_odc.py
@@ -67,31 +67,24 @@ def map_load_collection(id, process):
 """
 
 
-def map_xy(id, process):
-    """Map to xarray version of processes with input (x, y).
+def map_required(id, process) -> str:
+    """Map processes with required arguments only.
 
-    Creates a string like the following:
-    mul_6 = oeop.subtract(**{'x': dep_1, 'y': dep_2})
+    Currently processes with params ('x', 'y'), ('data', 'value'), ('base', 'p'), and ('x') are supported.
+    Creates a string like the following: sub_6 = oeop.subtract(**{'x': dep_1, 'y': dep_2})
 
     Returns: str
-
     """
-
     process_name = process['process_id']
-    params = {
-        'x': process['arguments']['x'],
-        'y': process['arguments']['y']
-    }
-    if isinstance(params['x'], dict) and 'from_node' in params['x']:
-        params['x'] = params['x']['from_node']
-    if isinstance(params['y'], dict) and 'from_node' in params['y']:
-        params['y'] = params['y']['from_node']
+    params = {arg_name: arg_value for arg_name, arg_value in process['arguments'].items()}
+    for key, value in params.items():
+        if isinstance(value, dict) and 'from_node' in value:
+            params[key] = value['from_node']
     params = convert_from_node_parameter(params)
     params_str = create_string(params)
 
     return f"""{id} = oeop.{process_name}({params_str})
 """
-
 
 def map_data(id, process, kwargs):
     """Map to xarray version of processes with input (data, param_1, ?param2, ...).
@@ -139,7 +132,6 @@ def convert_from_node_parameter(args_in, from_par=None):
         if from_par and isinstance(item, dict) and 'from_parameter' in item:
             if item['from_parameter'] == 'x':
                 args_in[k] = from_par['data']  # This fixes error when using the apply process
-            else:
             args_in[k] = from_par[item['from_parameter']]
 
     if len(args_in) == 1:
@@ -174,7 +166,7 @@ def create_string(dict_input):
     inputs = []
     to_remove = []
     for key, value in dict_input.items():
-        if key in ('x', 'y', 'data'):
+        if key in ('x', 'y', 'data', 'value', 'base', 'p'):
             to_remove.append(key)
             if isinstance(value, list):
                 val_str = "["

--- a/src/openeo_odc/map_to_odc.py
+++ b/src/openeo_odc/map_to_odc.py
@@ -2,7 +2,7 @@
 
 """
 
-from openeo_odc.map_processes_odc import map_xy, map_data, map_load_collection
+from openeo_odc.map_processes_odc import map_required, map_data, map_load_collection
 
 
 def map_to_odc(graph, odc_env, odc_url):
@@ -21,8 +21,8 @@ def map_to_odc(graph, odc_env, odc_url):
         if cur_node.parent_process: #parent process can be eiter reduce_dimension or apply
             if cur_node.parent_process.process_id == 'reduce_dimension':
                 kwargs['dimension'] = cur_node.parent_process.content['arguments']['dimension']
-        if tuple(cur_node.arguments.keys()) == ('x', 'y'):
-            nodes[cur_node.id] = map_xy(cur_node.id, cur_node.content)
+        if tuple(cur_node.arguments.keys()) in [('x', 'y'), ('x'), ('data', 'value'), ('base', 'p')]:
+            nodes[cur_node.id] = map_required(cur_node.id, cur_node.content)
         elif 'data' in tuple(cur_node.arguments.keys()):
             nodes[cur_node.id] = map_data(cur_node.id, cur_node.content, kwargs)
         elif 'id' in tuple(cur_node.arguments.keys()):

--- a/src/openeo_odc/map_to_odc.py
+++ b/src/openeo_odc/map_to_odc.py
@@ -59,21 +59,21 @@ def create_job_header(odc_env: str, dask_url: str):
     """Create job imports."""
     if odc_env is None:
         return f"""from dask.distributed import Client
-    import datacube
-    import openeo_processes as oeop
+import datacube
+import openeo_processes as oeop
 
-    # Initialize ODC instance
-    cube = datacube.Datacube()
-    # Connect to Dask Scheduler
-    client = Client('{dask_url}')
-    """
+# Initialize ODC instance
+cube = datacube.Datacube()
+# Connect to Dask Scheduler
+client = Client('{dask_url}')
+"""
     else:
         return f"""from dask.distributed import Client
-    import datacube
-    import openeo_processes as oeop
+import datacube
+import openeo_processes as oeop
 
-    # Initialize ODC instance
-    cube = datacube.Datacube(app='app_1', env='{odc_env}')
-    # Connect to Dask Scheduler
-    client = Client('{dask_url}')
-    """
+# Initialize ODC instance
+cube = datacube.Datacube(app='app_1', env='{odc_env}')
+# Connect to Dask Scheduler
+client = Client('{dask_url}')
+"""

--- a/tests/ref_jobs/evi_odc_ref.py
+++ b/tests/ref_jobs/evi_odc_ref.py
@@ -7,7 +7,7 @@ cube = datacube.Datacube(app='app_1', env='default')
 # Connect to Dask Scheduler
 client = Client('tcp://xx.yyy.zz.kk:8786')
 
-dc_0 = oeop.load_collection(odc_cube=cube, **{'product': 'boa_sentinel_2', 'x': (9.9, 10.0), 'y': (46.5, 46.6), 'time': ['2018-06-15', '2018-06-17'], 'dask_chunks': {'time': 'auto', 'x': 1000, 'y': 1000}, 'measurements': ['B08', 'B04', 'B02']})
+dc_0 = oeop.load_collection(odc_cube=cube, **{'product': 'boa_sentinel_2', 'dask_chunks': {'time': 'auto', 'x': 1000, 'y': 1000}, 'x': (9.9, 10.0), 'y': (46.5, 46.6), 'time': ['2018-06-15', '2018-06-16'], 'measurements': ['B08', 'B04', 'B02']})
 nir_2 = oeop.array_element(**{'data': dc_0, 'index': 0, 'dimension': 'bands'})
 red_3 = oeop.array_element(**{'data': dc_0, 'index': 1, 'dimension': 'bands'})
 blue_4 = oeop.array_element(**{'data': dc_0, 'index': 2, 'dimension': 'bands'})

--- a/tests/test_processes_data.py
+++ b/tests/test_processes_data.py
@@ -1,9 +1,11 @@
 """
 Tests processes with input type func(data, **kwargs)
 """
-
+import pytest
 from pytest import mark
 from openeo_odc.map_processes_odc import map_data
+
+from tests.utils import create_params
 
 
 @mark.parametrize("node_id, process_def, kwargs, process_ref",

--- a/tests/test_processes_xy.py
+++ b/tests/test_processes_xy.py
@@ -1,32 +1,130 @@
 """
 Tests processes with input type func(x, y)
 """
+from typing import Tuple, Any, Dict
 
-from pytest import mark
-from openeo_odc.map_processes_odc import map_xy
+import pytest
+from openeo_odc.map_processes_odc import map_required
+
+from tests.utils import create_params, set_process
 
 
-@mark.parametrize("node_id, process_def, process_ref",
-    [
-        (
-            "multiply_1",
-            {'process_id': 'multiply', 'arguments': {'x': 3, 'y': 6}},
-            "multiply_1 = oeop.multiply(**{'x': 3,'y': 6})\n"
-        ),
-        (
-            "multiply_2",
-            {'process_id': 'multiply', 'arguments': {'x': {'from_node': 'red_3'}, 'y': 6}},
-            "multiply_2 = oeop.multiply(**{'x': red_3,'y': 6})\n"
-        ),
-        (
-            "multiply_3",
-            {'process_id': 'multiply', 'arguments': {'x': {'from_node': 'red_3'}, 'y': {'from_node': 'blue_2'}}},
-            "multiply_3 = oeop.multiply(**{'x': red_3,'y': blue_2})\n"
-        )
+@pytest.fixture(
+    params=[
+        ({'x': 3, 'y': 6}, "{'x': 3,'y': 6}"),
+        ({'x': {'from_node': 'red_3'}, 'y': 6}, "{'x': red_3,'y': 6}"),
+        ({'x': {'from_node': 'red_3'}, 'y': {'from_node': 'blue_2'}}, "{'x': red_3,'y': blue_2}"),
     ]
 )
-def test_multiply(node_id, process_def, process_ref):
-    """Test all `multiply` conversions."""
+def get_xy_param(request):
+    return create_params("node_xy", request.param[0], request.param[1])
 
-    out = map_xy(node_id, process_def)
+
+@pytest.fixture(
+    params=[
+        ({'x': 3}, "{'x': 3}"),
+        ({'x': {'from_node': 'red_3'}}, "{'x': red_3}"),
+    ]
+)
+def get_x_param(request):
+    return create_params("node_x", request.param[0], request.param[1])
+
+
+@pytest.fixture(
+    params=[
+        ({'data': [1, 2, 3, 4], 'value': 4}, "{'data': [1, 2, 3, 4],'value': 4}"),
+        # ({'data': ['1', '2', '3', '4'], 'value': '4'}, "{'data': ['1', '2', '3', '4'],'value': '4'}"),
+        # ({'data': ['this', 'is', 'a', 'test'], 'value': 'test'}, "{'data': ['this', 'is', 'a', 'test'],'value': 'test'}"),
+        ({'data': {'from_node': 'red_3'}, 'value': 4}, "{'data': red_3,'value': 4}"),
+        ({'data': [1, 2, 3, 4], 'value': {'from_node': 'blue_2'}}, "{'data': [1, 2, 3, 4],'value': blue_2}"),
+    ]
+)
+def get_data_val_param(request):
+    return create_params("node_data_val", request.param[0], request.param[1])
+
+
+@pytest.mark.parametrize("process", (
+        "gt",
+        "gte",
+        "lt",
+        "lte",
+        "add",
+        "divide",
+        "mod",
+        "subtract",
+        "multiply",
+        "normalized_difference",
+        "arctan2",
+        "and",
+        "or",
+        "xor",
+))
+def test_xy(process: str, get_xy_param: Tuple[str, Dict[str, Any], str]):
+    """Test conversions of processes with input x, y."""
+    node_id, process_def, process_ref = set_process(*get_xy_param, process)
+
+    out = map_required(node_id, process_def)
+
+    assert out == process_ref
+
+
+@pytest.mark.parametrize("process", (
+        "is_nan",
+        "is_no_data",
+        "is_valid",
+        "not",
+        "absolute",
+        "int",
+        "sgn",
+        "sqrt",
+        "constant",
+        "ln",
+        "ceil",
+        "floor",
+        "arccos",
+        "arcsin",
+        "arctan",
+        "arcsinh",
+        "arctanh",
+        "cos",
+        "cosh",
+        "sin",
+        "sinh",
+        "tan",
+        "tanh",
+))
+def test_x(process: str, get_x_param: Tuple[str, Dict[str, Any], str]):
+    """Test conversions of processes with input x."""
+    node_id, process_def, process_ref = set_process(*get_x_param, process)
+
+    out = map_required(node_id, process_def)
+
+    assert out == process_ref
+
+
+@pytest.mark.parametrize('process', (
+        "array_contains",
+        "array_find",
+))
+def test_data_value(process: str, get_data_val_param: Tuple[str, Dict[str, Any], str]):
+    node_id, process_def, process_ref = set_process(*get_data_val_param, process)
+
+    out = map_required(node_id, process_def)
+
+    assert out == process_ref
+
+
+@pytest.mark.parametrize("arg_in,arg_out", (
+        ({'base': 4, 'p': 2}, "{'base': 4,'p': 2}"),
+        ({'base': 4.1, 'p': 2.9}, "{'base': 4.1,'p': 2.9}"),
+        ({'base': {'from_node': 'red_3'}, 'p': 4}, "{'base': red_3,'p': 4}"),
+        ({'base': 4, 'p': {'from_node': 'blue_2'}}, "{'base': 4,'p': blue_2}"),
+        ({'base': {'from_node': 'red_3'}, 'p': {'from_node': 'blue_2'}}, "{'base': red_3,'p': blue_2}"),
+))
+def test_power(arg_in: Dict[str, Any], arg_out: str):
+    """Test conversions of power process with input base, p."""
+    node_id, process_def, process_ref = set_process(*create_params("node_power", arg_in, arg_out), "power")
+
+    out = map_required(node_id, process_def)
+
     assert out == process_ref

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,0 +1,16 @@
+from typing import Any, Dict, Tuple
+
+
+def create_params(node_id: str, args_in: Dict[str, Any], args_out: str) -> Tuple[str, Dict[str, Any], str]:
+    """Format input and expected output of process."""
+    return node_id, \
+        {"process_id": "PLACEHOLDER", "arguments": args_in}, \
+        f"{node_id} = oeop.PLACEHOLDER(**{args_out})\n"
+
+
+def set_process(node_id: str, process_def: Dict[str, Any], process_ref: str, process_name: str) \
+        -> Tuple[str, Dict[str, Any], str]:
+    """Set the PLACEHOLDER to the given process name."""
+    process_def["process_id"] = process_name
+    process_ref = process_ref.replace("PLACEHOLDER", process_name)
+    return node_id, process_def, process_ref


### PR DESCRIPTION
* extend support from processes with (x, y) arguments to all processes with required arguments only (e.g. for (x, y), (x), (data, value))
* add tests for all supported processes