### PR TITLE
test_aggregate_spatial now gets geometry arguments correctly

### DIFF
--- a/src/openeo_odc/string_creation.py
+++ b/src/openeo_odc/string_creation.py
@@ -44,6 +44,9 @@ def create_param_string(dict_input: dict, process_name: str):
                         else:
                             val_str += f"'{val}', "
                     inputs.append(f"'{key}': {val_str[:-2]}]")
+                elif isinstance(value,dict):
+                    inputs.append(f"'{key}': {str(value)}")
+
             # in apply_dimension a callable process from oeop is needed, this converts 'mean' into 'oeop.mean'!
             elif key in ['process', 'reducer', 'condition'] and process_name in ['apply_dimension', 'aggregate_temporal_period', 'filter_labels', 'aggregate_spatial']:
                 if isinstance(value, str):

--- a/tests/test_processes_xy.py
+++ b/tests/test_processes_xy.py
@@ -183,7 +183,7 @@ def test_aggregate_temporal_period(arg_in: Dict[str, Any], arg_out: str):
     assert out == process_ref
 
 @pytest.mark.parametrize("arg_in,arg_out", (
-        ({'data': {'from_node': 'data'}, 'geometries': {'type': 'MultiPoint', 'coordinates': [[1, 2], [3, 4]]}, 'reducer': 'mean', 'target_dimension': 'result'}, "{'data': _data, 'reducer': oeop.mean, 'geometries': {'type': 'MultiPoint', 'coordinates': [[1, 2], [3, 4]]}, 'target_dimension': 'result'}"),
+        ({'data': {'from_node': 'data'}, 'reducer': 'mean', 'geometries': {'type': 'MultiPoint', 'coordinates': [[1, 2], [3, 4]]}, 'target_dimension': 'result'}, "{'data': _data, 'reducer': oeop.mean, 'geometries': {'type': 'MultiPoint', 'coordinates': [[1, 2], [3, 4]]}, 'target_dimension': 'result'}"),
 ))
 def test_aggregate_spatial(arg_in: Dict[str, Any], arg_out: str):
     """Test conversions of aggregate_temporal_period process."""
@@ -204,3 +204,4 @@ def test_predict_random_forest(arg_in: Dict[str, Any], arg_out: str):
 
     assert out == process_ref
 
+ 


### PR DESCRIPTION
@ValentinaHutter , I tested to create a pull request to see how it worked. Now the argument is not ignored when its a dict. I also updated the test case, since the arguments are generated in another order than before. I guess this is still correct. We still need to fix the code that gets executed, but you we're on that already so I go back to waiting...