### PR TITLE
Now subtracts one second from end time in Load Collection

### DIFF
--- a/src/openeo_odc/map_processes_odc.py
+++ b/src/openeo_odc/map_processes_odc.py
@@ -57,7 +57,7 @@ def map_load_collection(id, process):
     params['time'] = []
     if 'temporal_extent' in process['arguments']:
         def exclusive_date(date):
-            return np.datetime_as_string(np.datetime64(date) - np.timedelta64(1, 'D'), timezone='UTC') # Substracts one day
+            return np.datetime_as_string(np.datetime64(date) - np.timedelta64(1, 's'), timezone='UTC') # Achieves, "up to but not including"
         if process['arguments']['temporal_extent'] is not None and len(process['arguments']['temporal_extent'])>0:
             timeStart = '1970-01-01'
             timeEnd   = str(datetime.now()).split(' ')[0] # Today is the default date for timeEnd, to include all the dates if not specified
@@ -112,7 +112,7 @@ def map_load_result(id, process) -> str:
     if 'temporal_extent' in process['arguments']:
         params['time'] = []
         def exclusive_date(date):
-            return np.datetime_as_string(np.datetime64(date) - np.timedelta64(1, 'D'), timezone='UTC') # Substracts one day
+            return np.datetime_as_string(np.datetime64(date) - np.timedelta64(1, 's'), timezone='UTC') # Achieves, "up to but not including"
         if process['arguments']['temporal_extent'] is not None and len(process['arguments']['temporal_extent'])>0:
             timeStart = '1970-01-01'
             timeEnd   = str(datetime.now()).split(' ')[0] # Today is the default date for timeEnd, to include all the dates if not specified


### PR DESCRIPTION
Now subtracts one second from end time in Load Collection to achieve up to but not including time scope. After some git problems, both instances of the exclusive_data function were found and updated.

 